### PR TITLE
fix typo in isort config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: isort
         args:
           - --project
-          - marvin
+          - cachet_netbox_sync
           - --case-sensitive
           - --section-default
           - THIRDPARTY


### PR DESCRIPTION
There seems to be a c/p typo in the _isort_ configuration for _pre-commit_: I guess it should set `cachet_netbox_sync` instead of `marvin` for a known first party. I don't think this causes any issues though, 1st party imports seem to be all relative.